### PR TITLE
Updated change registration

### DIFF
--- a/admin/camper_modal.js
+++ b/admin/camper_modal.js
@@ -83,6 +83,9 @@ function postAjax(obj,camper_id) {
 	xmlhttp.send("x=" + encodeURIComponent(param));
 }
 function changeCamp(r_id,camper_id,old_id){
+	moveForward = confirm("Please note that all payments will also be changed over.	But if you are changing program areas, then the base camp fees will be assigned the wrong fee area.  Do you want to continue?");
+	if(!moveForward)
+		return;
 	var info = {"change_to_id" : document.getElementById(r_id).value, "registration_id" : r_id,"camper_id":camper_id,"old_id":old_id};
 	console.log(info);
 	postAjax(info,camper_id);

--- a/update_registration.php
+++ b/update_registration.php
@@ -65,21 +65,6 @@ else if(isset($obj["registration_id"])){
 		), 
 		array( '%d' ) 
 	);
-	//Get all the payment id's that are tied to this camp and change the camp_id's assosiated with it
-	$camps = $wpdb->get_results($wpdb->prepare("SELECT payment_id FROM " . $GLOBALS['srbc_payments'] . " WHERE camp_id=%d AND camper_id=%d",$obj["old_id"],$obj["camper_id"]));
-	foreach($camps as $camp){
-		$wpdb->update( 
-			$GLOBALS['srbc_payments'], 
-			array( 
-				'camp_id' => $obj["change_to_id"], 
-			), 
-			array( 'payment_id' => $camp->payment_id ), 
-			array( 
-				'%d', 
-			), 
-			array( '%d' ) 
-		);
-	}
 	echo "Change Successful";
 	//Also change over all the payments made for that camp
 }


### PR DESCRIPTION
Deprecated camper_id and camp_id in payment database.  Deleted code cause registration_id doens't change when changing a camp.  Also added a dialog to confirm change.